### PR TITLE
zoktai any%: add gbp katana manip

### DIFF
--- a/src/zoktai/any.md
+++ b/src/zoktai/any.md
@@ -510,6 +510,7 @@ Select the ![][icon_broad_sword] Broadsword and ![][icon_long_sword] Long Sword 
 
 - **Emulator: 34.07 seconds**
 - **Nintendo DS: 34.25 seconds**
+- **Game Boy Player: 34.23 seconds**
 
 Do precisely 15 strikes in this forge.  
 Get at least two GREATs to guarantee an SP weapon.  


### PR DESCRIPTION
Based on empirical testing. It's within the margin of error for the DS timing, and even with that I have a 5/5 success rate.